### PR TITLE
Open attachments in DispVMs from message windows

### DIFF
--- a/chrome/content/qubesattachment.js
+++ b/chrome/content/qubesattachment.js
@@ -95,7 +95,9 @@ var qubesattachment = {
 
 };
 
-if (window.location.href == "chrome://messenger/content/messenger.xul") {
+if (window.location.href == "chrome://messenger/content/messenger.xul" ||
+    window.location.href == "chrome://messenger/content/messageWindow.xul")
+{
 	var versionChecker =
 		Components.classes["@mozilla.org/xpcom/version-comparator;1"].getService(Components.interfaces.nsIVersionComparator);
 	if (versionChecker.compare(Application.version, "5.0") >= 0) {


### PR DESCRIPTION
This is a relatively simple commit to fix the opening of attachments in DisposableVMs when e-mails are viewed in message windows as opposed to message tabs.

To the best of my knowledge, this commit applies to both QubesOS R3.2 and QubesOS R4.0, but I have tested this change only on R3.2.

Thank you! 