### PR TITLE
Make sure that preferences.js is packaged

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -76,7 +76,7 @@ install-vm:
 	install -d $(DESTDIR)/$(EXTDIR)/chrome/locale/en-US
 	install -t $(DESTDIR)/$(EXTDIR)/chrome/locale/en-US chrome/locale/en-US/qubesattachment.dtd
 	install -d $(DESTDIR)/$(EXTDIR)/chrome/content
-	install -t $(DESTDIR)/$(EXTDIR)/chrome/content chrome/content/options.xul chrome/content/qubesattachment.js chrome/content/messenger.xul
+	install -t $(DESTDIR)/$(EXTDIR)/chrome/content chrome/content/options.xul chrome/content/qubesattachment.js chrome/content/messenger.xul chrome/content/preferences.js
 	install -d $(DESTDIR)/$(EXTDIR)/chrome/skin
 	install -t $(DESTDIR)/$(EXTDIR)/chrome/skin chrome/skin/qubesattachment.css
 	install -d $(DESTDIR)/$(EXTDIR)/defaults/preferences

--- a/rpm_spec/thunderbird-qubes.spec.in
+++ b/rpm_spec/thunderbird-qubes.spec.in
@@ -60,6 +60,7 @@ rm -rf $RPM_BUILD_ROOT
 %{extdir}/manifest.json
 %{extdir}/chrome/locale/en-US/qubesattachment.dtd
 %{extdir}/chrome/content/options.xul
+%{extdir}/chrome/content/preferences.js
 %{extdir}/chrome/content/qubesattachment.js
 %{extdir}/chrome/content/messenger.xul
 %{extdir}/chrome/skin/qubesattachment.css


### PR DESCRIPTION
@marmarek, my apologies for not testing the packaged version for pull request #5. I tested pull request #5 with a manually packaged .zip (i.e., .xpi) file, and I appear to have forgotten the inclusion of the new file `chrome/content/preferences.js` in the .rpm/.deb packages. This commit should resolve this issue. (I tested this commit's packaged version on a Fedora 30-based AppVM.)