### PR TITLE
Disable CentOS package build

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,7 +1,11 @@
 ifeq ($(PACKAGE_SET),vm)
   # Enable when Thunderbird 68+ will be in Debian
   #DEBIAN_BUILD_DIRS := debian
+
+  # Enable when Thunderbird 68+ will be in CentOS
+  ifneq ($(DISTRIBUTION), centos)
   RPM_SPEC_FILES := rpm_spec/thunderbird-qubes.spec
+  endif
 endif
 
 # vim: filetype=make


### PR DESCRIPTION
re-enable only after TB 68+ will be there.

QubesOS/qubes-issues#5318