### PR TITLE
Re-enable build for CentOS 8

### DIFF
--- a/Makefile.builder
+++ b/Makefile.builder
@@ -1,11 +1,6 @@
 ifeq ($(PACKAGE_SET),vm)
-  # Enable when Thunderbird 68+ will be in Debian
   DEBIAN_BUILD_DIRS := debian
-
-  # Enable when Thunderbird 68+ will be in CentOS
-  ifneq ($(DISTRIBUTION), centos)
   RPM_SPEC_FILES := rpm_spec/thunderbird-qubes.spec
-  endif
 endif
 
 # vim: filetype=make


### PR DESCRIPTION
CentOS now do have Thunderbird 68.

Fixes QubesOS/qubes-issues#5318